### PR TITLE
Future method consistency

### DIFF
--- a/R/helpers_ggplot.R
+++ b/R/helpers_ggplot.R
@@ -161,7 +161,7 @@ annotate_conditions_with_panel <- function(plot, panel_name) {
 
 #' @importFrom ggplot2 ggplot_build
 #' @export
-ggplot_build.phylepic_ggplot <- function(plot) {
+ggplot_build.phylepic_ggplot <- function(plot, ...) {
   panel_name <- attr(plot, "phylepic.panel")
   build <- withCallingHandlers(
     NextMethod(generic = "ggplot_build", object = plot),


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
This PR silences a S3 method consistency warning we found during this check.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun